### PR TITLE
Remove extraneous exported symbols

### DIFF
--- a/src/chebyshev.rs
+++ b/src/chebyshev.rs
@@ -16,7 +16,7 @@
 //! Based on the Fortran routine dcsevl by W. Fullerton.
 //! Adapted from R. Broucke, Algorithm 446, CACM., 16, 254 (1973).
 
-use crate::ml_warn_return_nan;
+use crate::nmath::*;
 
 /// `chebyshev_init` determines the number of terms for the
 /// double precision orthogonal series `dos` needed to insure

--- a/src/dnorm.rs
+++ b/src/dnorm.rs
@@ -2,11 +2,8 @@ use std::f64::{MANTISSA_DIGITS, MAX, MIN_EXP};
 
 use libm::ldexp;
 
-use crate::{
-    r_forceint,
-    rmath::{ML_LN2, M_1_SQRT_2PI},
-    ML_NAN, ML_POSINF, M_LN_SQRT_2PI,
-};
+use crate::nmath::*;
+use crate::rmath::*;
 
 /// Compute the density of the normal distribution.
 pub fn dnorm4(x: f64, mu: f64, sigma: f64, give_log: bool) -> f64 {

--- a/src/gamma.rs
+++ b/src/gamma.rs
@@ -1,9 +1,7 @@
-use crate::{
-    chebyshev_eval, ml_warn_return_nan,
-    nmath::M_LN_SQRT_2PI,
-    rmath::{ML_LN2, M_PI},
-    sinpi, ML_NAN, ML_NEGINF, ML_POSINF,
-};
+use crate::chebyshev::*;
+use crate::nmath::*;
+use crate::rmath::*;
+use crate::sinpi;
 
 /// Chebyshev coefficients for gamma function
 const GAMCS: [f64; 42] = [

--- a/src/lgamma.rs
+++ b/src/lgamma.rs
@@ -1,7 +1,7 @@
 use std::f64::INFINITY;
 
-use crate::{gammafn, lgammacor, sinpi};
 use crate::nmath::*;
+use crate::{gammafn, lgammacor, sinpi};
 
 /// Machine dependent constants for IEEE double precision
 const XMAX: f64 = 2.532_737_276_080_075_8e305;

--- a/src/lgamma.rs
+++ b/src/lgamma.rs
@@ -1,6 +1,7 @@
 use std::f64::INFINITY;
 
-use crate::{gammafn, lgammacor, sinpi, ML_NAN, M_LN_SQRT_2PI};
+use crate::{gammafn, lgammacor, sinpi};
+use crate::nmath::*;
 
 /// Machine dependent constants for IEEE double precision
 const XMAX: f64 = 2.532_737_276_080_075_8e305;

--- a/src/lgammacor.rs
+++ b/src/lgammacor.rs
@@ -1,4 +1,5 @@
-use crate::{chebyshev_eval, ml_warn_return_nan};
+use crate::chebyshev_eval;
+use crate::nmath::*;
 
 const ALGMCS: [f64; 15] = [
     1.666_389_480_451_863_4e-1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,8 @@ mod stirlerr;
 
 // Use only explicit exports and no wildcard exports to avoid accidentally
 // exporting symbols that should not be exported.
-pub use chebyshev::chebyshev_init;
 pub use chebyshev::chebyshev_eval;
+pub use chebyshev::chebyshev_init;
 pub use cospi::cospi;
 pub use cospi::sinpi;
 pub use cospi::tanpi;
@@ -36,3 +36,8 @@ pub use rmath::pnorm;
 pub use rmath::qnorm;
 // pub use pgamma::*;
 pub use stirlerr::stirlerr;
+
+// TODO: Remove these exports later; once they are used by lgamma.
+pub use nmath::r_d_nonint_check;
+pub use nmath::r_log1_exp;
+pub use nmath::r_nonint;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,16 +19,20 @@ mod qnorm;
 mod rmath;
 mod stirlerr;
 
-pub use chebyshev::*;
-pub use cospi::*;
+// Use only explicit exports and no wildcard exports to avoid accidentally
+// exporting symbols that should not be exported.
+pub use chebyshev::chebyshev_init;
+pub use chebyshev::chebyshev_eval;
+pub use cospi::cospi;
+pub use cospi::sinpi;
+pub use cospi::tanpi;
 // pub use dpois::*;
-pub use gamma::*;
-pub use lgamma::*;
-pub use lgammacor::*;
-pub use libc::*;
-pub use nmath::*;
+pub use gamma::gammafn;
+pub use lgamma::lgammafn;
+pub use lgamma::lgammafn_sign;
+pub use lgammacor::lgammacor;
 pub use rmath::dnorm;
 pub use rmath::pnorm;
 pub use rmath::qnorm;
 // pub use pgamma::*;
-pub use stirlerr::*;
+pub use stirlerr::stirlerr;

--- a/src/nmath.rs
+++ b/src/nmath.rs
@@ -27,7 +27,8 @@ pub fn r_log1_exp(x: f64) -> f64 {
         (-x.exp()).ln_1p()
     }
 }
-fn r_nonint(x: f64) -> bool {
+
+pub fn r_nonint(x: f64) -> bool {
     let nearest_int = x.round();
     (x - nearest_int).abs() > 1e-7 * f64::max(1.0, x.abs())
 }

--- a/src/stirlerr.rs
+++ b/src/stirlerr.rs
@@ -1,4 +1,5 @@
-use crate::{lgammafn, M_LN_SQRT_2PI};
+use crate::lgamma::*;
+use crate::nmath::*;
 
 const S0: f64 = 0.083_333_333_333_333_33; /* 1/12 */
 const S1: f64 = 0.002_777_777_777_777_778; /* 1/360 */


### PR DESCRIPTION
This avoids exporting symbols that we shouldn't export such as `ML_NAN`.

I considered writing a test script to verify the symbols, but maybe just being explicit in `src/lib.rs` is more straightforward.