### PR TITLE
Check `import_granularity = "Item"`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: 'test-${{ matrix.rust }}'
       - name: Cargo test
         run: |
           cargo test
@@ -43,6 +45,8 @@ jobs:
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: 'check-format'
 
       - name: Cargo clippy
         run: |
@@ -58,7 +62,7 @@ jobs:
           echo 'imports_granularity = "Item"' > rustfmt.toml
           cargo fmt --all --check
 
-          copy rustfmt.toml test/
+          cp rustfmt.toml test/
           cd test/
           cargo fmt --all --check
 
@@ -68,6 +72,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: 'check-docs'
       - name: cargo doc
         env:
           RUSTDOCFLAGS: "-D rustdoc::all -A rustdoc::private-doc-tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,46 +11,7 @@ on:
   workflow_dispatch: null
 
 jobs:
-  check:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Stable Rust
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          components: 'clippy, rustfmt'
-          toolchain: 'stable'
-
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
-
-      - name: Cargo clippy
-        run: |
-          cargo clippy --all-targets --all-features -- -D warnings
-          cd test/
-          cargo clippy --all-targets --all-features -- -D warnings
-
-      - name: Cargo fmt
-        run: |
-          cargo fmt --all --check
-          cd test/
-          cargo fmt --all --check
-
-  check-docs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: cargo doc
-        env:
-          RUSTDOCFLAGS: "-D rustdoc::all -A rustdoc::private-doc-tests"
-        run: cargo doc --all-features --no-deps
-
-  test-versions:
+  test:
     needs: check
     runs-on: ubuntu-latest
     strategy:
@@ -67,3 +28,49 @@ jobs:
           cargo test
           cd test/
           cargo test
+
+  check-format:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Stable Rust
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          components: 'clippy, rustfmt'
+          toolchain: 'nightly'
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Cargo clippy
+        run: |
+          cargo clippy --all-targets --all-features -- -D warnings
+          cd test/
+          cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Cargo fmt
+        run: |
+          # Only available on nightly, unfortunately.
+          # Ensures each import has its own `use` statement.
+          # This makes it easier to quickly modify the imports in editors.
+          echo 'imports_granularity = "Item"' > rustfmt.toml
+          cargo fmt --all --check
+
+          copy rustfmt.toml test/
+          cd test/
+          cargo fmt --all --check
+
+  check-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo doc
+        env:
+          RUSTDOCFLAGS: "-D rustdoc::all -A rustdoc::private-doc-tests"
+        run: cargo doc --all-features --no-deps
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ on:
 
 jobs:
   test:
-    needs: check
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/src/dnorm.rs
+++ b/src/dnorm.rs
@@ -1,4 +1,6 @@
-use std::f64::{MANTISSA_DIGITS, MAX, MIN_EXP};
+use std::f64::MANTISSA_DIGITS;
+use std::f64::MAX;
+use std::f64::MIN_EXP;
 
 use libm::ldexp;
 

--- a/src/lgamma.rs
+++ b/src/lgamma.rs
@@ -1,8 +1,8 @@
 use std::f64::INFINITY;
 
-use crate::nmath::*;
 use crate::gammafn;
 use crate::lgammacor;
+use crate::nmath::*;
 use crate::sinpi;
 
 /// Machine dependent constants for IEEE double precision

--- a/src/lgamma.rs
+++ b/src/lgamma.rs
@@ -1,7 +1,9 @@
 use std::f64::INFINITY;
 
 use crate::nmath::*;
-use crate::{gammafn, lgammacor, sinpi};
+use crate::gammafn;
+use crate::lgammacor;
+use crate::sinpi;
 
 /// Machine dependent constants for IEEE double precision
 const XMAX: f64 = 2.532_737_276_080_075_8e305;

--- a/src/nmath.rs
+++ b/src/nmath.rs
@@ -1,4 +1,6 @@
-use std::f64::{INFINITY, NAN, NEG_INFINITY};
+use std::f64::INFINITY;
+use std::f64::NAN;
+use std::f64::NEG_INFINITY;
 
 use crate::dpq::r_d__0;
 use crate::rmath::ML_LN2;

--- a/src/nmath.rs
+++ b/src/nmath.rs
@@ -1,6 +1,7 @@
 use std::f64::{INFINITY, NAN, NEG_INFINITY};
 
-use crate::{dpq::r_d__0, rmath::ML_LN2};
+use crate::dpq::r_d__0;
+use crate::rmath::ML_LN2;
 
 pub const ML_POSINF: f64 = INFINITY;
 pub const ML_NEGINF: f64 = NEG_INFINITY;

--- a/src/rmath.rs
+++ b/src/rmath.rs
@@ -2,7 +2,9 @@ use crate::dnorm::dnorm4;
 use crate::pnorm::pnorm5;
 use crate::qnorm::qnorm5;
 
-use std::f64::consts::{LN_2, PI, SQRT_2};
+use std::f64::consts::LN_2;
+use std::f64::consts::PI;
+use std::f64::consts::SQRT_2;
 
 pub const M_PI: f64 = PI;
 pub const M_SQRT2: f64 = SQRT_2;


### PR DESCRIPTION
Checking `import_granularity = "Item"` only in CI and not locally because it's only available on `nightly`. This makes it easy to run the tests on `stable` locally. It shouldn't be too hard to satisfy `import_granularity` manually.