### PR TITLE
Conditionally `println!` only in `std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,7 @@ repository = "https://github.com/poweranalyses-org/rmathlib"
 
 [dependencies]
 libm = "0.2"
+
+[features]
+default = ["std"]
+std = []

--- a/src/gamma.rs
+++ b/src/gamma.rs
@@ -96,6 +96,7 @@ pub fn gammafn(x: f64) -> f64 {
                 return ml_warn_return_nan();
             }
             if y < XSML {
+                #[cfg(feature = "std")]
                 println!("gammafn: Range warning");
                 return if x > 0.0 { ML_POSINF } else { ML_NEGINF };
             }
@@ -134,6 +135,7 @@ pub fn gammafn(x: f64) -> f64 {
             }
             let sinpiy = sinpi(y);
             if sinpiy == 0.0 {
+                #[cfg(feature = "std")]
                 println!("gammafn: Range warning - Negative integer arg - overflow");
                 return ML_POSINF;
             }

--- a/src/lgamma.rs
+++ b/src/lgamma.rs
@@ -86,6 +86,7 @@ pub fn lgammafn_sign(x: f64, sgn: Option<&mut i32>) -> f64 {
         if ((x - x.trunc() - 0.5) * ans / x).abs() < DXREL {
             // Warning: answer less than half precision
             // because the argument is too near a negative integer
+            #[cfg(feature = "std")]
             println!("** should NEVER happen! *** [lgamma.rs: Neg.int, y={y}]");
             return ML_NAN; // Placeholder for warning
         }

--- a/src/lgammacor.rs
+++ b/src/lgammacor.rs
@@ -43,6 +43,7 @@ pub fn lgammacor(x: f64) -> f64 {
     if x < 10.0 {
         return ml_warn_return_nan();
     } else if x >= XMAX {
+        #[cfg(feature = "std")]
         println!("lgammacor: Underflow warning");
         // Allow to underflow
     } else if x < XBIG {

--- a/src/nmath.rs
+++ b/src/nmath.rs
@@ -9,6 +9,7 @@ pub const ML_POSINF: f64 = INFINITY;
 pub const ML_NEGINF: f64 = NEG_INFINITY;
 
 pub fn ml_warn_return_nan() -> f64 {
+    #[cfg(feature = "std")]
     println!("argument out of domain");
     ML_NAN
 }
@@ -42,6 +43,7 @@ pub fn r_forceint(x: f64) -> f64 {
 
 pub fn r_d_nonint_check(x: f64, give_log: bool) -> f64 {
     if r_nonint(x) {
+        #[cfg(feature = "std")]
         println!("non-integer x = {x}");
     }
     r_d__0(give_log)


### PR DESCRIPTION
This is a first step to `no_std`.
Annotates all `println!` statements with `#[cfg(feature = "std")]`. Sets the default features to be `std`.