### PR TITLE
Set edition to 2018

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         # 1.43 is our lower bound because that is when f64::EPSILON
         # was introduced, which libm depends on.
         # 1.43 was unable to update registry.
-        toolchain: ['1.48', 'stable', 'beta']
+        toolchain: ['1.49', 'stable', 'beta']
     steps:
       - uses: actions/checkout@v4
       - run: rustup default ${{ matrix.toolchain }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         # 1.43 is our lower bound because that is when f64::EPSILON
         # was introduced, which libm depends on.
         # 1.43 was unable to update registry.
-        toolchain: ['1.60', 'stable', 'beta']
+        toolchain: ['1.44', 'stable', 'beta']
     steps:
       - uses: actions/checkout@v4
       - run: rustup default ${{ matrix.toolchain }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         # 1.43 is our lower bound because that is when f64::EPSILON
         # was introduced, which libm depends on.
         # 1.43 was unable to update registry.
-        toolchain: ['1.45', 'stable', 'beta']
+        toolchain: ['1.46', 'stable', 'beta']
     steps:
       - uses: actions/checkout@v4
       - run: rustup default ${{ matrix.toolchain }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,20 @@ jobs:
       matrix:
         # Version should be at least 1.43 because that is when f64::EPSILON
         # was introduced, which libm depends on.
-        # Next, anything lower than 1.46 was unable to update registry.
+        # Next, anything lower than 1.46 was unable to update the registry in
+        # GitHub Actions.
         toolchain: ['1.46', 'stable', 'beta']
     steps:
-      - uses: actions/checkout@v4
-      - run: rustup default ${{ matrix.toolchain }}
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Rust
+        run: |
+          rustup update ${{ matrix.toolchain }}
+          rustup default ${{ matrix.toolchain }}
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: 'test-${{ matrix.rust }}'
       - name: Cargo test
         run: |
           cargo test
@@ -37,10 +46,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          components: 'clippy, rustfmt'
-          toolchain: 'nightly'
+        run: |
+          rustup update nightly
+          rustup default nightly
+          rustup component add clippy
+          rustup component add rustfmt
 
       - name: Cache
         uses: Swatinem/rust-cache@v2
@@ -69,12 +79,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - name: Install Rust
+        run: |
+          rustup update stable
+          rustup default stable
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
         with:
           prefix-key: 'check-docs'
-      - name: cargo doc
+      - name: Cargo doc
         env:
           RUSTDOCFLAGS: "-D rustdoc::all -A rustdoc::private-doc-tests"
         run: cargo doc --all-features --no-deps
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,13 @@ jobs:
       matrix:
         # 1.43 is our lower bound because that is when f64::EPSILON
         # was introduced, which libm depends on.
-        rust: ['1.44', 'stable', 'beta']
+        # 1.43 was unable to update registry.
+        rust: ['1.43', 'stable', 'beta']
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: 'test-${{ matrix.rust }}'
       - name: Cargo test
         run: |
           cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         # 1.43 is our lower bound because that is when f64::EPSILON
         # was introduced, which libm depends on.
         # 1.43 was unable to update registry.
-        toolchain: ['1.49', 'stable', 'beta']
+        toolchain: ['1.50', 'stable', 'beta']
     steps:
       - uses: actions/checkout@v4
       - run: rustup default ${{ matrix.toolchain }}
@@ -36,13 +36,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Stable Rust
+      - name: Install Rust
         uses: dtolnay/rust-toolchain@v1
         with:
           components: 'clippy, rustfmt'
           toolchain: 'nightly'
 
-      - name: Rust cache
+      - name: Cache
         uses: Swatinem/rust-cache@v2
         with:
           prefix-key: 'check-format'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,10 @@ jobs:
         # 1.43 is our lower bound because that is when f64::EPSILON
         # was introduced, which libm depends on.
         # 1.43 was unable to update registry.
-        rust: ['1.43', 'stable', 'beta']
+        toolchain: ['1.46', 'stable', 'beta']
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust }}
+      - run: rustup default {{ matrix.toolchain }}
       - name: Cargo test
         run: |
           cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: ['1.40', 'stable', 'beta']
+        rust: ['1.50', 'stable', 'beta']
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         # 1.43 is our lower bound because that is when f64::EPSILON
         # was introduced, which libm depends on.
-        rust: ['1.43', 'stable', 'beta']
+        rust: ['1.44', 'stable', 'beta']
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         # 1.43 is our lower bound because that is when f64::EPSILON
         # was introduced, which libm depends on.
         # 1.43 was unable to update registry.
-        toolchain: ['1.44', 'stable', 'beta']
+        toolchain: ['1.45', 'stable', 'beta']
     steps:
       - uses: actions/checkout@v4
       - run: rustup default ${{ matrix.toolchain }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # 1.43 is our lower bound because that is when f64::EPSILON
+        # Version should be at least 1.43 because that is when f64::EPSILON
         # was introduced, which libm depends on.
-        # 1.43 was unable to update registry.
+        # Next, anything lower than 1.46 was unable to update registry.
         toolchain: ['1.46', 'stable', 'beta']
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         # 1.43 is our lower bound because that is when f64::EPSILON
         # was introduced, which libm depends on.
         # 1.43 was unable to update registry.
-        toolchain: ['1.50', 'stable', 'beta']
+        toolchain: ['1.54', 'stable', 'beta']
     steps:
       - uses: actions/checkout@v4
       - run: rustup default ${{ matrix.toolchain }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: ['1.31', 'stable', 'beta']
+        rust: ['1.40', 'stable', 'beta']
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, beta]
+        rust: ['1.31', 'stable', 'beta']
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         # 1.43 is our lower bound because that is when f64::EPSILON
         # was introduced, which libm depends on.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         # 1.43 is our lower bound because that is when f64::EPSILON
         # was introduced, which libm depends on.
         # 1.43 was unable to update registry.
-        toolchain: ['1.46', 'stable', 'beta']
+        toolchain: ['1.47', 'stable', 'beta']
     steps:
       - uses: actions/checkout@v4
       - run: rustup default ${{ matrix.toolchain }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: ['1.50', 'stable', 'beta']
+        # 1.43 is our lower bound because that is when f64::EPSILON
+        # was introduced, which libm depends on.
+        rust: ['1.43', 'stable', 'beta']
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         # 1.43 is our lower bound because that is when f64::EPSILON
         # was introduced, which libm depends on.
         # 1.43 was unable to update registry.
-        toolchain: ['1.56', 'stable', 'beta']
+        toolchain: ['1.60', 'stable', 'beta']
     steps:
       - uses: actions/checkout@v4
       - run: rustup default ${{ matrix.toolchain }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         toolchain: ['1.46', 'stable', 'beta']
     steps:
       - uses: actions/checkout@v4
-      - run: rustup default {{ matrix.toolchain }}
+      - run: rustup default ${{ matrix.toolchain }}
       - name: Cargo test
         run: |
           cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         # 1.43 is our lower bound because that is when f64::EPSILON
         # was introduced, which libm depends on.
         # 1.43 was unable to update registry.
-        toolchain: ['1.47', 'stable', 'beta']
+        toolchain: ['1.48', 'stable', 'beta']
     steps:
       - uses: actions/checkout@v4
       - run: rustup default ${{ matrix.toolchain }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         # 1.43 is our lower bound because that is when f64::EPSILON
         # was introduced, which libm depends on.
         # 1.43 was unable to update registry.
-        toolchain: ['1.54', 'stable', 'beta']
+        toolchain: ['1.56', 'stable', 'beta']
     steps:
       - uses: actions/checkout@v4
       - run: rustup default ${{ matrix.toolchain }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,12 +20,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Stable Rust
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: 'stable'
+      - name: Install Rust
+        run: |
+          rustup update stable
+          rustup default stable
 
-      - name: Rust cache
+      - name: Cache
         uses: Swatinem/rust-cache@v2
 
       - name: Build docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,9 @@ name = "rmathlib"
 description = "A Rust Port of R's C Library of Special Functions"
 version = "1.0.0"
 include = ["src/", "LICENSE", "README.md"]
-edition = "2021"
+# libm also targets the 2018 edition.
+# Allows support for Rust 1.31.0 upwards.
+edition = "2018"
 authors = [
   "Rik Huijzer <github@huijzer.xyz>",
   "Jose Storopoli <jose@storopoli.io>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,6 @@ name = "rmathlib"
 description = "A Rust Port of R's C Library of Special Functions"
 version = "1.0.0"
 include = ["src/", "LICENSE", "README.md"]
-# libm also targets the 2018 edition.
-# Allows support for Rust 1.31.0 upwards.
 edition = "2018"
 authors = [
   "Rik Huijzer <github@huijzer.xyz>",

--- a/src/lgamma.rs
+++ b/src/lgamma.rs
@@ -86,7 +86,7 @@ pub fn lgammafn_sign(x: f64, sgn: Option<&mut i32>) -> f64 {
         if ((x - x.trunc() - 0.5) * ans / x).abs() < DXREL {
             // Warning: answer less than half precision
             // because the argument is too near a negative integer
-            println!("** should NEVER happen! *** [lgamma.rs: Neg.int, y={y}]");
+            println!("** should NEVER happen! *** [lgamma.rs: Neg.int, y={}]", y);
             return ML_NAN; // Placeholder for warning
         }
         ans

--- a/src/nmath.rs
+++ b/src/nmath.rs
@@ -42,7 +42,7 @@ pub fn r_forceint(x: f64) -> f64 {
 
 pub fn r_d_nonint_check(x: f64, give_log: bool) -> f64 {
     if r_nonint(x) {
-        println!("non-integer x = {x}");
+        println!("non-integer x = {}", x);
     }
     r_d__0(give_log)
 }

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test-rmathlib"
 description = "A test crate which is for comparing C and Rust code and should not be published."
-edition = "2021"
+edition = "2018"
 # Required for old Rust versions.
 version = "1.0.0"
 

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -2,6 +2,8 @@
 name = "test-rmathlib"
 description = "A test crate which is for comparing C and Rust code and should not be published."
 edition = "2021"
+# Required for old Rust versions.
+version = "1.0.0"
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
Should allow supporting older Rust versions. Edition 2021 is only available from Rust 1.56.0 onward.